### PR TITLE
Add oid to Actiongroup

### DIFF
--- a/tahoma_api/tahoma_api.py
+++ b/tahoma_api/tahoma_api.py
@@ -909,6 +909,7 @@ class ActionGroup:
         """Initalize the Tahoma Action Group."""
         self.__last_update = data['lastUpdateTime']
         self.__name = data['label']
+        self.__oid  = data['oid']
 
         self.__actions = []
 
@@ -924,6 +925,11 @@ class ActionGroup:
     def name(self):
         """Get name of action group."""
         return self.__name
+    
+    @property
+    def oid(self):
+        """Get oid of the action group."""
+        return self.__oid
 
     @property
     def actions(self):


### PR DESCRIPTION
This adds the oid to an action group. This is needed to trigger the action group. I've got the implementation for HomeAssistant ready but I'm missing this in the API.