### PR TITLE
fix TypeError

### DIFF
--- a/tahoma_api/tahoma_api.py
+++ b/tahoma_api/tahoma_api.py
@@ -46,7 +46,7 @@ class TahomaApi:
             raise Exception(
                 "Not a valid result for login, " +
                 "protocol error: " + request.status_code + ' - ' +
-                request.reason + "(" + error + ")")
+                request.reason + "(" + str(error) + ")")
 
         if 'error' in result.keys():
             raise Exception("Could not login: " + result['error'])


### PR DESCRIPTION
During a outage on somfy's end today I got the following error:

`can only concatonate str (not "int") to str`
the error was on the following line:
`request.reason + "(" + error + ")")`